### PR TITLE
Remove CNAME config for staceyfanner.com

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.staceyfanner.com

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,0 @@
-www.staceyfanner.com


### PR DESCRIPTION
Removes `CNAME` and `public/CNAME` files that referenced the no-longer-owned `www.staceyfanner.com` domain. The site will now serve from `staceyjf.github.io`.